### PR TITLE
Updates for Rspec 2.*

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,8 @@
+# A sample Gemfile
+source "https://rubygems.org"
+
+group :test do
+  gem 'rspec'
+  gem 'rake'
+  gem 'jeweler'
+end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,0 +1,30 @@
+GEM
+  remote: https://rubygems.org/
+  specs:
+    diff-lcs (1.1.3)
+    git (1.2.5)
+    jeweler (1.8.3)
+      bundler (~> 1.0)
+      git (>= 1.2.5)
+      rake
+      rdoc
+    json (1.6.6)
+    rake (0.9.2.2)
+    rdoc (3.12)
+      json (~> 1.4)
+    rspec (2.8.0)
+      rspec-core (~> 2.8.0)
+      rspec-expectations (~> 2.8.0)
+      rspec-mocks (~> 2.8.0)
+    rspec-core (2.8.0)
+    rspec-expectations (2.8.0)
+      diff-lcs (~> 1.1.2)
+    rspec-mocks (2.8.0)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  jeweler
+  rake
+  rspec

--- a/Rakefile
+++ b/Rakefile
@@ -20,23 +20,21 @@ rescue LoadError
   puts "Jeweler (or a dependency) not available. Install it with: gem install jeweler"
 end
 
-require 'spec/rake/spectask'
-Spec::Rake::SpecTask.new(:spec) do |spec|
-  spec.libs << 'lib' << 'spec'
-  spec.spec_files = FileList['spec/**/*_spec.rb']
+require 'rspec/core/rake_task'
+RSpec::Core::RakeTask.new(:spec) do |spec|
+  spec.rspec_opts = '--color --format=documentation -I lib -I spec'
+  spec.pattern = "spec/**/*_spec.rb"
 end
 
-Spec::Rake::SpecTask.new(:rcov) do |spec|
-  spec.libs << 'lib' << 'spec'
+RSpec::Core::RakeTask.new(:rcov) do |spec|
+  spec.rspec_opts = '-I lib -I spec'
   spec.pattern = 'spec/**/*_spec.rb'
   spec.rcov = true
 end
 
-task :spec => :check_dependencies
+task :default => [:spec]
 
-task :default => :spec
-
-require 'rake/rdoctask'
+require 'rdoc/task'
 Rake::RDocTask.new do |rdoc|
   version = File.exist?('VERSION') ? File.read('VERSION') : ""
 

--- a/lib/capistrano/spec.rb
+++ b/lib/capistrano/spec.rb
@@ -43,7 +43,7 @@ module Capistrano
     end
 
     module Matchers
-      extend ::Rspec::Matchers::DSL
+      extend ::RSpec::Matchers::DSL
 
       define :callback do |task_name|
         extend Helpers

--- a/lib/capistrano/spec.rb
+++ b/lib/capistrano/spec.rb
@@ -43,7 +43,7 @@ module Capistrano
     end
 
     module Matchers
-      extend ::Spec::Matchers::DSL
+      extend ::Rspec::Matchers::DSL
 
       define :callback do |task_name|
         extend Helpers

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,8 +1,8 @@
 $LOAD_PATH.unshift(File.dirname(__FILE__))
 $LOAD_PATH.unshift(File.join(File.dirname(__FILE__), '..', 'lib'))
 require 'capistrano-spec'
-require 'spec'
-require 'spec/autorun'
+require 'rspec'
+require 'rspec/autorun'
 
 Spec::Runner.configure do |config|
   


### PR DESCRIPTION
These commits simply update all the code that is still referring to pre-2.0 spec constants.  The end effect is just the removal of deprecation warnings when running tests that require capistrano-spec.  Included is also a Bundler Gemfile for getting the environment setup properly for running the sole test for the gem itself.

I realize this changes the Rakefile, but that has the same problems with outdated task names.

Thanks for the great gem, it's awesome to have a framework for testing Cap tasks.
