### PR TITLE
Fix for deprecation message

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -4,6 +4,6 @@ require 'capistrano-spec'
 require 'rspec'
 require 'rspec/autorun'
 
-Spec::Runner.configure do |config|
-  
+RSpec.configure do |config|
+
 end


### PR DESCRIPTION
Just a quick-one to fix: Spec::Runner.configure -> RSpec.configure
