### PR TITLE
Stub commands and their output to test capture calls.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,4 +5,5 @@ group :test do
   gem 'rspec'
   gem 'rake'
   gem 'jeweler'
+  gem 'capistrano'
 end

--- a/README.rdoc
+++ b/README.rdoc
@@ -73,7 +73,7 @@ Alright, we can start testing by making Capistrano::Configuration and load Capis
       @configuration = Capistrano::Configuration.new
       Capistrano::Speak.load_into(@configuration)
     end
-  
+
   end
 
 
@@ -84,7 +84,7 @@ Now, remember, if you +set+ values, you can access them using +fetch+:
   before do
     @configuration.set :foo, 'bar'
   end
-  
+
   it "should define foo" do
     @configuration.fetch(:foo).should == 'bar'
   end
@@ -96,7 +96,7 @@ You can also find and execute tasks, so you can verify if you successfully set a
     before do
       @configuration.find_and_execute_task('speak')
     end
-    
+
     it "should define message" do
       @configuration.fetch(:message).should == 'oh hai'
     end
@@ -145,6 +145,37 @@ You also test [callbacks](http://rubydoc.info/github/capistrano/capistrano/maste
 
   it "performs foo:bar before deploy:finalize_update" do
     @configuration.should callback('foo:bar').before('deploy:finalize_update')
+  end
+
+You can also stub requests if you need to access their output:
+
+  task :pwd do
+    set :pwd, capture('pwd')
+  end
+
+  it 'should capture working directory' do
+    @configuration.stub_command 'pwd', data: '/path/to/working/dir'
+    @configuration.fetch(:pwd).should == '/path/to/working/dir'
+  end
+
+Additional options are +channel+ and +stream+ for testing custom +run+ blocks:
+
+  task :custom do
+    invoke_command 'pwd', :via => :sudo do |ch, stream, data|
+      # magical foo
+    end
+  end
+
+As +sudo+ and +invoke_command+ use +run+ internal and +capture+ uses
++invoke_command+ they are also stub-able by specifying the exact command.
+
+  task :sudo_pwd do
+    set :pwd, capture('pwd', :via => :sudo)
+  end
+
+  it 'should capture sudo working directory' do
+    @configuration.stub_command 'sudo -p 'sudo password: ' pwd', data: '/sudo/dir'
+    @configuration.fetch(:pwd).should == '/sudo/dir'
   end
 
 == Real world examples

--- a/lib/capistrano/spec.rb
+++ b/lib/capistrano/spec.rb
@@ -40,7 +40,8 @@ module Capistrano
         @stubbed_commands ||= {}
       end
 
-      def stub_command(command, options = {})
+      def stub_command(command, options = {}, &block)
+        options[:with] = block if block_given?
         stubbed_commands[command] = { :stream => :out, :data => '' }.merge options
       end
     end

--- a/lib/capistrano/spec.rb
+++ b/lib/capistrano/spec.rb
@@ -12,7 +12,15 @@ module Capistrano
       def run(cmd, options={}, &block)
         runs[cmd] = {:options => options, :block => block}
         if (stub = stubbed_commands[cmd])
-          block.call stub[:channel], stub[:stream], stub[:data] if block_given?
+          raise ::Capistrano::CommandError if stub[:fail]
+          raise stub[:raise] if stub[:raise]
+
+          if block_given?
+            data = stub[:data]
+            data = stub[:with].call(cmd) if stub[:with].respond_to? :call
+
+            block.call stub[:channel], stub[:stream], data
+          end
         end
       end
 

--- a/lib/capistrano/spec.rb
+++ b/lib/capistrano/spec.rb
@@ -11,6 +11,9 @@ module Capistrano
 
       def run(cmd, options={}, &block)
         runs[cmd] = {:options => options, :block => block}
+        if (stub = stubed_commands[cmd])
+          block.call stub[:channel], stub[:stream], stub[:data]
+        end
       end
 
       def runs
@@ -24,7 +27,14 @@ module Capistrano
       def uploads
         @uploads ||= {}
       end
-      
+
+      def stubed_commands
+        @stubed_commands ||= {}
+      end
+
+      def stub_command(command, options = {})
+        stubed_commands[command] = { stream: :out, data: '' }.merge options
+      end
     end
 
     module Helpers
@@ -158,7 +168,7 @@ module Capistrano
         failure_message_for_should do |actual|
           "expected configuration to run #{cmd}, but did not"
         end
-        
+
       end
 
     end

--- a/lib/capistrano/spec.rb
+++ b/lib/capistrano/spec.rb
@@ -15,12 +15,10 @@ module Capistrano
           raise ::Capistrano::CommandError if stub[:fail]
           raise stub[:raise] if stub[:raise]
 
-          if block_given?
-            data = stub[:data]
-            data = stub[:with].call(cmd) if stub[:with].respond_to? :call
+          data = stub[:data]
+          data = stub[:with].call(cmd) if stub[:with].respond_to? :call
 
-            block.call stub[:channel], stub[:stream], data
-          end
+          block.call stub[:channel], stub[:stream], data if block_given?
         end
       end
 

--- a/lib/capistrano/spec.rb
+++ b/lib/capistrano/spec.rb
@@ -12,7 +12,7 @@ module Capistrano
       def run(cmd, options={}, &block)
         runs[cmd] = {:options => options, :block => block}
         if (stub = stubbed_commands[cmd])
-          block.call stub[:channel], stub[:stream], stub[:data]
+          block.call stub[:channel], stub[:stream], stub[:data] if block_given?
         end
       end
 

--- a/lib/capistrano/spec.rb
+++ b/lib/capistrano/spec.rb
@@ -11,7 +11,7 @@ module Capistrano
 
       def run(cmd, options={}, &block)
         runs[cmd] = {:options => options, :block => block}
-        if (stub = stubed_commands[cmd])
+        if (stub = stubbed_commands[cmd])
           block.call stub[:channel], stub[:stream], stub[:data]
         end
       end
@@ -28,12 +28,12 @@ module Capistrano
         @uploads ||= {}
       end
 
-      def stubed_commands
-        @stubed_commands ||= {}
+      def stubbed_commands
+        @stubbed_commands ||= {}
       end
 
       def stub_command(command, options = {})
-        stubed_commands[command] = { stream: :out, data: '' }.merge options
+        stubbed_commands[command] = { :stream => :out, :data => '' }.merge options
       end
     end
 

--- a/spec/stub_commands_spec.rb
+++ b/spec/stub_commands_spec.rb
@@ -49,6 +49,21 @@ describe 'Command stubbing' do
 
   it 'should allow to stub commands without block' do
     @configuration.stub_command 'pwd'
-    expect { @configuration.no_block.should }.to_not raise_error(NoMethodError)
+    expect { @configuration.no_block }.to_not raise_error(NoMethodError)
+  end
+
+  it 'should allow to stub command processing' do
+    @configuration.stub_command 'pwd', with: proc { |cmd| cmd }
+    @configuration.remote_pwd.should == 'pwd'
+  end
+
+  it 'should allow to stub command processing with error' do
+    @configuration.stub_command 'pwd', raise: ::Capistrano::CommandError
+    expect { @configuration.no_block }.to raise_error(::Capistrano::CommandError)
+  end
+
+  it 'should allow to stub command processing with CommandError' do
+    @configuration.stub_command 'pwd', fail: true
+    expect { @configuration.no_block }.to raise_error(::Capistrano::CommandError)
   end
 end

--- a/spec/stub_commands_spec.rb
+++ b/spec/stub_commands_spec.rb
@@ -23,22 +23,22 @@ describe 'Command stubbing' do
   end
 
   it 'should allow to stub command output' do
-    @configuration.stub_command 'pwd', data: '/stubded/path'
+    @configuration.stub_command 'pwd', :data => '/stubded/path'
     @configuration.remote_pwd.should == '/stubded/path'
   end
 
   it 'should allow to stub sudo command output' do
-    @configuration.stub_command "sudo -p 'sudo password: ' pwd", data: '/stubbed/path'
+    @configuration.stub_command "sudo -p 'sudo password: ' pwd", :data => '/stubbed/path'
     @configuration.remote_sudo_pwd.should == '/stubbed/path'
   end
 
   it 'should allow to stub custom command output' do
-    @configuration.stub_command 'pwd', data: '/stubbed/path'
+    @configuration.stub_command 'pwd', :data => '/stubbed/path'
     @configuration.custom_pwd.should == 'out: /stubbed/path'
   end
 
   it 'should allow to stub stream' do
-    @configuration.stub_command 'pwd', data: '/stubbed/path', stream: :err
+    @configuration.stub_command 'pwd', :data => '/stubbed/path', :stream => :err
     @configuration.custom_pwd.should == 'err: /stubbed/path'
   end
 end

--- a/spec/stub_commands_spec.rb
+++ b/spec/stub_commands_spec.rb
@@ -19,6 +19,11 @@ describe 'Command stubbing' do
           return "#{stream}: #{data}"
         end
       end
+
+      def no_block
+      	run 'pwd'
+      	nil
+      end
     end
   end
 
@@ -40,5 +45,10 @@ describe 'Command stubbing' do
   it 'should allow to stub stream' do
     @configuration.stub_command 'pwd', :data => '/stubbed/path', :stream => :err
     @configuration.custom_pwd.should == 'err: /stubbed/path'
+  end
+
+  it 'should allow to stub commands without block' do
+    @configuration.stub_command 'pwd'
+    expect { @configuration.no_block.should }.to_not raise_error(NoMethodError)
   end
 end

--- a/spec/stub_commands_spec.rb
+++ b/spec/stub_commands_spec.rb
@@ -1,0 +1,44 @@
+require 'spec_helper'
+require 'capistrano'
+
+describe 'Command stubbing' do
+  before do
+    @configuration = Capistrano::Configuration.new
+    @configuration.extend Capistrano::Spec::ConfigurationExtension
+    @configuration.load do
+      def remote_pwd
+        capture 'pwd'
+      end
+
+      def remote_sudo_pwd
+        capture 'pwd', :via => :sudo
+      end
+
+      def custom_pwd
+        run 'pwd' do |ch, stream, data|
+          return "#{stream}: #{data}"
+        end
+      end
+    end
+  end
+
+  it 'should allow to stub command output' do
+    @configuration.stub_command 'pwd', data: '/stubded/path'
+    @configuration.remote_pwd.should == '/stubded/path'
+  end
+
+  it 'should allow to stub sudo command output' do
+    @configuration.stub_command "sudo -p 'sudo password: ' pwd", data: '/stubbed/path'
+    @configuration.remote_sudo_pwd.should == '/stubbed/path'
+  end
+
+  it 'should allow to stub custom command output' do
+    @configuration.stub_command 'pwd', data: '/stubbed/path'
+    @configuration.custom_pwd.should == 'out: /stubbed/path'
+  end
+
+  it 'should allow to stub stream' do
+    @configuration.stub_command 'pwd', data: '/stubbed/path', stream: :err
+    @configuration.custom_pwd.should == 'err: /stubbed/path'
+  end
+end

--- a/spec/stub_commands_spec.rb
+++ b/spec/stub_commands_spec.rb
@@ -57,6 +57,11 @@ describe 'Command stubbing' do
     @configuration.remote_pwd.should == 'pwd'
   end
 
+  it 'should allow to stub command processing (2)' do
+    @configuration.stub_command 'pwd' do |cmd| cmd end
+    @configuration.remote_pwd.should == 'pwd'
+  end
+
   it 'should allow to stub command processing with error' do
     @configuration.stub_command 'pwd', raise: ::Capistrano::CommandError
     expect { @configuration.no_block }.to raise_error(::Capistrano::CommandError)

--- a/spec/stub_commands_spec.rb
+++ b/spec/stub_commands_spec.rb
@@ -58,8 +58,10 @@ describe 'Command stubbing' do
   end
 
   it 'should allow to stub command processing (2)' do
-    @configuration.stub_command 'pwd' do |cmd| cmd end
-    @configuration.remote_pwd.should == 'pwd'
+  	testvar = false
+    @configuration.stub_command 'pwd' do |cmd| testvar = true end
+    @configuration.no_block
+    testvar.should be_true
   end
 
   it 'should allow to stub command processing with error' do


### PR DESCRIPTION
I've added an option to stub commands and specify their output to test `capture` calls.

Example:

``` ruby
# capistrano helper method
def remote_ruby_version
  capture('ruby -v || true') =~ /(\d+\.\d+\.\d+p\d+)/ ? $1 : nil
end

#specs
it 'should return ruby version' do
  @configuration.stub_command 'ruby -v || true', data: 'ruby 2.0.0p0 (2013-02-24...)'
  @configuration.remote_ruby_version.should == '2.0.0p0'
end
```

As a stub invokes the block given to `run` also `sudo` or `invoke_command` with custom blocks can be stubbed by specifying the exact command. `channel` and `stream` block arguments can be given same way as `data` e.g. for testing error `:err` stream handling.

``` ruby
# capistrano helper method
def installed_packages
  sudo 'aptitude search ~i' do |channel, stream, data|
    # magical foo
  end
end

#specs
it 'should do something on error' do
  @configuration.stub_command "sudo -p 'sudo password: ' aptitude search ~i", 
    stream: :err, data: 'command not found', channel: nil
  # ...
end
```

I've also added specs for stubbing commands in a standalone spec file but I've needed to add capistrano as a test dependency.
