### PR TITLE
Flexible uploaded matcher

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,4 +5,5 @@ group :test do
   gem 'rspec'
   gem 'rake'
   gem 'jeweler'
+  gem 'capistrano'
 end

--- a/lib/capistrano/spec.rb
+++ b/lib/capistrano/spec.rb
@@ -24,7 +24,7 @@ module Capistrano
       def uploads
         @uploads ||= {}
       end
-      
+
     end
 
     module Helpers
@@ -124,13 +124,13 @@ module Capistrano
       end
 
       define :have_uploaded do |path|
+        @to = nil # Reset `to` because it will influence next match otherwise.
+
         match do |configuration|
-          upload = configuration.uploads[path]
-          if @to
-            upload && upload[:to] == @to
-          else
-            upload
-          end
+          uploads = configuration.uploads
+          uploads = uploads.select { |f, u| f == path } if path
+          uploads = uploads.select { |f, u| u[:to] == @to } if @to
+          uploads.any?
         end
 
         def to(to)
@@ -158,7 +158,7 @@ module Capistrano
         failure_message_for_should do |actual|
           "expected configuration to run #{cmd}, but did not"
         end
-        
+
       end
 
     end

--- a/spec/uploaded_spec.rb
+++ b/spec/uploaded_spec.rb
@@ -1,0 +1,44 @@
+require 'spec_helper'
+require 'capistrano'
+
+describe 'Capistrano has uploaded' do
+  include Capistrano::Spec::Matchers
+
+  before do
+    @configuration = Capistrano::Configuration.new
+    @configuration.extend Capistrano::Spec::ConfigurationExtension
+    @configuration.load do
+      def upload_from_to
+        upload 'source.file', 'target.file'
+      end
+
+      def upload_to
+        upload 'temp.XC3PO.file', 'target.file' # E.g. uploading generated tar
+      end
+
+      def upload_from
+        upload 'source.file', 'temp.XC3PO.file' # E.g. uploading to temp file
+      end
+    end
+  end
+
+  it 'some file' do
+    @configuration.upload 'source.file', 'target.file'
+    @configuration.should have_uploaded
+  end
+
+  it 'a specific file to a specific location' do
+    @configuration.upload_from_to
+    @configuration.should have_uploaded('source.file').to('target.file')
+  end
+
+  it 'a specific file to some location' do
+    @configuration.upload_from
+    @configuration.should have_uploaded('source.file')
+  end
+
+  it 'some file to a specific location' do
+    @configuration.upload_to
+    @configuration.should have_uploaded.to('target.file')
+  end
+end


### PR DESCRIPTION
I've made the `have_uploaded` matcher more flexible to allow testing only for source or target path. I need this to test if a generated tar file was uploaded. Therefore I cannot specify a source path as it is some random temp file name.

See the specs on how to use:

``` ruby
describe 'Capistrano uploaded' do
  # ...
  it 'some file' do
    @configuration.upload 'source.file', 'target.file'
    @configuration.should have_uploaded
  end

  it 'a specific file to a specific location' do
    @configuration.upload_from_to
    @configuration.should have_uploaded('source.file').to('target.file')
  end

  it 'a specific file to some location' do
    @configuration.upload_from
    @configuration.should have_uploaded('source.file')
  end

  it 'some file to a specific location' do
    @configuration.upload_to
    @configuration.should have_uploaded.to('target.file')
  end
end
```
