### PR TITLE
Added spec for main module matchers and helpers

### DIFF
--- a/spec/capistrano-spec_spec.rb
+++ b/spec/capistrano-spec_spec.rb
@@ -18,56 +18,68 @@ describe Capistrano::Spec do
       foo = double(foo)
     end
 
-    it "should have a #callback matcher" do
+    it "has a #callback matcher" do
       expect{@configuration.should callback(foo)}.to_not raise_error(NoMethodError)
     end
 
-    it "should have a #have_uploaded matcher" do
+    it "has a #have_uploaded matcher" do
       expect{@configuration.should have_uploaded(foo)}.to_not raise_error(NoMethodError)
     end
 
-    it "should have a #have_run matcher" do
+    it "has a #have_run matcher" do
       expect{@configuration.should have_run(foo)}.to_not raise_error(NoMethodError)
     end
 
-    it "#have_run will not raise error when run is in recipe" do
+  end
+
+  describe 'have_run' do
+
+    it "will not raise error when run is in recipe" do
       @configuration.find_and_execute_task('fake:thing')
       expect{@configuration.should have_run("do some stuff")}.to_not raise_error(RSpec::Expectations::ExpectationNotMetError, /expected configuration to run .*\s*, but did not/)
     end
 
-    it "#have_run will raise error when run not in recipe" do
+    it "will raise error when run not in recipe" do
       @configuration.find_and_execute_task('fake:thing')
       expect{@configuration.should have_run("don't find me")}.to raise_error(RSpec::Expectations::ExpectationNotMetError, /expected configuration to run .*\s*, but did not/)
     end
 
-    it "#have_uploaded will not raise error when upload is in recipe" do
+  end
+
+  describe 'have_uploaded' do
+
+    it "will not raise error when upload is in recipe" do
       @configuration.find_and_execute_task('fake:thing')
       expect{@configuration.should have_uploaded('foo').to('/tmp/foo')}.to_not raise_error(RSpec::Expectations::ExpectationNotMetError, /expected configuration to upload .*\s* to .*\s* but did not/)
     end
 
-    it "#have_uploaded will raise error when run upload not in recipe" do
+    it "will raise error when run upload not in recipe" do
       @configuration.find_and_execute_task('fake:thing')
       expect{@configuration.should have_uploaded('bar').to('/tmp/bar')}.to raise_error(RSpec::Expectations::ExpectationNotMetError, /expected configuration to upload .*\s* to .*\s* but did not/)
     end
+  end
 
-    it "#have_gotten will not raise error when get is in recipe" do
+  describe 'have_gotten' do
+    it "will not raise error when get is in recipe" do
       @configuration.find_and_execute_task('fake:thing')
       expect{@configuration.should have_gotten('/tmp/baz').to('baz')}.to_not raise_error(RSpec::Expectations::ExpectationNotMetError, /expected configuration to get .*\s* to .*\s* but did not/)
     end
 
-    it "#have_gotten will raise error when get not in recipe" do
+    it "will raise error when get not in recipe" do
       @configuration.find_and_execute_task('fake:thing')
       expect{@configuration.should have_gotten('/tmp/blegga').to('blegga')}.to raise_error(RSpec::Expectations::ExpectationNotMetError, /expected configuration to get .*\s* to .*\s* but did not/)
     end
+  end
 
-    it "#callback will not raise error when `before` callback has occured" do
+  describe 'callback' do
+
+    it "will not raise error when `before` callback has occured" do
       expect{@configuration.should callback('fake:thing').before('fake:stuff_and_things')}.to_not raise_error(RSpec::Expectations::ExpectationNotMetError, /expected configuration to callback .*\s* before .*\s*, but did not/)
     end
 
-    it "#callback will not raise error when `after` callback has occured" do
+    it "will not raise error when `after` callback has occured" do
       expect{@configuration.should callback('fake:other_thing').after('fake:thing')}.to_not raise_error(RSpec::Expectations::ExpectationNotMetError, /expected configuration to callback .*\s* after .*\s*, but did not/)
     end
-
   end
 
 end

--- a/spec/capistrano-spec_spec.rb
+++ b/spec/capistrano-spec_spec.rb
@@ -1,7 +1,73 @@
-require File.expand_path(File.dirname(__FILE__) + '/spec_helper')
+require 'spec_helper'
+require 'capistrano'
 
-describe "CapistranoSpec" do
-  it "fails" do
-    fail "hey buddy, you should probably rename this file and start specing for real"
+require_relative 'recipe/FakeRecipe'
+
+describe Capistrano::Spec do
+
+  before do
+    @configuration = Capistrano::Configuration.new
+    @configuration.extend(Capistrano::Spec::ConfigurationExtension)
+    @configuration.extend(Capistrano::FakeRecipe)
+    Capistrano::FakeRecipe.load_into(@configuration)
   end
+
+  describe Capistrano::Spec::Matchers do
+
+    before do
+      foo = double(foo)
+    end
+
+    it "should have a #callback matcher" do
+      expect{@configuration.should callback(foo)}.to_not raise_error(NoMethodError)
+    end
+
+    it "should have a #have_uploaded matcher" do
+      expect{@configuration.should have_uploaded(foo)}.to_not raise_error(NoMethodError)
+    end
+
+    it "should have a #have_run matcher" do
+      expect{@configuration.should have_run(foo)}.to_not raise_error(NoMethodError)
+    end
+
+    it "#have_run will not raise error when run is in recipe" do
+      @configuration.find_and_execute_task('fake:thing')
+      expect{@configuration.should have_run("do some stuff")}.to_not raise_error(RSpec::Expectations::ExpectationNotMetError, /expected configuration to run .*\s*, but did not/)
+    end
+
+    it "#have_run will raise error when run not in recipe" do
+      @configuration.find_and_execute_task('fake:thing')
+      expect{@configuration.should have_run("don't find me")}.to raise_error(RSpec::Expectations::ExpectationNotMetError, /expected configuration to run .*\s*, but did not/)
+    end
+
+    it "#have_uploaded will not raise error when upload is in recipe" do
+      @configuration.find_and_execute_task('fake:thing')
+      expect{@configuration.should have_uploaded('foo').to('/tmp/foo')}.to_not raise_error(RSpec::Expectations::ExpectationNotMetError, /expected configuration to upload .*\s* to .*\s* but did not/)
+    end
+
+    it "#have_uploaded will raise error when run upload not in recipe" do
+      @configuration.find_and_execute_task('fake:thing')
+      expect{@configuration.should have_uploaded('bar').to('/tmp/bar')}.to raise_error(RSpec::Expectations::ExpectationNotMetError, /expected configuration to upload .*\s* to .*\s* but did not/)
+    end
+
+    it "#have_gotten will not raise error when get is in recipe" do
+      @configuration.find_and_execute_task('fake:thing')
+      expect{@configuration.should have_gotten('/tmp/baz').to('baz')}.to_not raise_error(RSpec::Expectations::ExpectationNotMetError, /expected configuration to get .*\s* to .*\s* but did not/)
+    end
+
+    it "#have_gotten will raise error when get not in recipe" do
+      @configuration.find_and_execute_task('fake:thing')
+      expect{@configuration.should have_gotten('/tmp/blegga').to('blegga')}.to raise_error(RSpec::Expectations::ExpectationNotMetError, /expected configuration to get .*\s* to .*\s* but did not/)
+    end
+
+    it "#callback will not raise error when `before` callback has occured" do
+      expect{@configuration.should callback('fake:thing').before('fake:stuff_and_things')}.to_not raise_error(RSpec::Expectations::ExpectationNotMetError, /expected configuration to callback .*\s* before .*\s*, but did not/)
+    end
+
+    it "#callback will not raise error when `after` callback has occured" do
+      expect{@configuration.should callback('fake:other_thing').after('fake:thing')}.to_not raise_error(RSpec::Expectations::ExpectationNotMetError, /expected configuration to callback .*\s* after .*\s*, but did not/)
+    end
+
+  end
+
 end

--- a/spec/recipe/fakerecipe.rb
+++ b/spec/recipe/fakerecipe.rb
@@ -1,0 +1,32 @@
+require 'capistrano'
+  module Capistrano
+    module FakeRecipe
+      def self.load_into(configuration)
+        configuration.load do
+          before "fake:stuff_and_things", "fake:thing"
+          after "fake:thing", "fake:other_thing"
+          namespace :fake do
+            desc "thing and run fake manifests"
+            task :thing do
+              set :bar, "baz"
+              run('do some stuff')
+              upload("foo", "/tmp/foo")
+              get('/tmp/baz', 'baz')
+            end
+            desc "More fake tasks!"
+            task :other_thing do
+              #
+            end
+            desc "You get the picture..."
+            task :stuff_and_things do
+              #
+            end
+          end
+        end
+      end
+    end
+  end
+
+  if Capistrano::Configuration.instance
+    Capistrano::FakeRecipe.load_into(Capistrano::Configuration.instance)
+  end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,9 +1,11 @@
 $LOAD_PATH.unshift(File.dirname(__FILE__))
 $LOAD_PATH.unshift(File.join(File.dirname(__FILE__), '..', 'lib'))
+require 'capistrano'
 require 'capistrano-spec'
 require 'rspec'
 require 'rspec/autorun'
 
 RSpec.configure do |config|
-
+	config.include Capistrano::Spec::Matchers
+	config.include Capistrano::Spec::Helpers
 end


### PR DESCRIPTION
Was writing some specs for the main matchers and stuff and thinking over the layout of the specs and what to do, and now that @jgraichen's stuff has added some specs, I thought I might as well add it now :+1: 

So, I'll probably change the formatting to match up with the existing specs, move the recipe in-line into the spec file etc.

Anyone got any major bugbears? @jgraichen @relistan @technicalpickles?

Thanks :smiley_cat: 
