### PR TITLE
Add a `#have_put` matcher to test `#put` action.

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -126,6 +126,11 @@ One thing you might be wondering now is... that's cool, but what about working w
     @configuration.should have_gotten('/tmp/bar').to('bar')
   end
 
+  it "should have put" do
+    @configuration.put 'some: content', '/config.yml'
+    @configuration.should have_put('some: content').to('/config.yml')
+  end
+
 You also test [callbacks](http://rubydoc.info/github/capistrano/capistrano/master/Capistrano/Configuration/Callbacks) to see if your tasks are being called at the right time:
 
   require 'capistrano'

--- a/lib/capistrano/spec.rb
+++ b/lib/capistrano/spec.rb
@@ -176,6 +176,56 @@ module Capistrano
 
       end
 
+      define :have_put do |content|
+        @to = nil
+
+        match do |configuration|
+          uploads = configuration.uploads.reduce([]) do |memo, (upload, options)|
+            # the {#put} method creates a {StringIO} object.
+            # @see {StringIO#string}
+            if upload.respond_to?(:string) && upload.string == content
+              memo << options
+            end
+
+            memo
+          end
+
+          if @to
+            uploads.any? { |upload| upload[:to] == @to }
+          else
+            !uploads.empty?
+          end
+        end
+
+        def to(path)
+          @to = path
+          self
+        end
+
+        failure_message_for_should do |configuration|
+          if @to
+            "expected configuration to put #{content.inspect} to #{@to.inspect}, but did not"
+          else
+            "expected configuration to put #{content.inspect}, but did not"
+          end
+        end
+
+        failure_message_for_should_not do |configuration|
+          if @to
+            "expected configuration to not put #{content.inspect} to #{@to.inspect}, but did"
+          else
+            "expected configuration to not put #{content.inspect}, but did"
+          end
+        end
+
+        description do
+          if @to
+            "puts the content #{content.inspect} to #{@to.inspect}"
+          else
+            "puts the content #{content.inspect}"
+          end
+        end
+      end
     end
   end
 end

--- a/lib/capistrano/spec.rb
+++ b/lib/capistrano/spec.rb
@@ -180,15 +180,11 @@ module Capistrano
         @to = nil
 
         match do |configuration|
-          uploads = configuration.uploads.reduce([]) do |memo, (upload, options)|
+          uploads = configuration.uploads.select do |upload, _|
             # the {#put} method creates a {StringIO} object.
             # @see {StringIO#string}
-            if upload.respond_to?(:string) && upload.string == content
-              memo << options
-            end
-
-            memo
-          end
+            upload.respond_to?(:string) && upload.string == content
+          end.values
 
           if @to
             uploads.any? { |upload| upload[:to] == @to }

--- a/spec/capistrano-spec_spec.rb
+++ b/spec/capistrano-spec_spec.rb
@@ -67,4 +67,38 @@ describe Capistrano::Spec do
     end
   end
 
+  describe 'have_put' do
+    context 'when a path is given' do
+      it "will not raise error when put is in recipe" do
+        fake_recipe.find_and_execute_task('fake:thing')
+        expect do
+          should have_put('fake content').to('/tmp/put')
+        end.to_not raise_error(RSpec::Expectations::ExpectationNotMetError, /expected configuration to put .*\s* to .*\s*, but did not/)
+      end
+
+      it "will raise error when put is not in recipe" do
+        fake_recipe.find_and_execute_task('fake:thing')
+        expect do
+          should have_put('real content').to('/tmp/wherever')
+        end.to raise_error(RSpec::Expectations::ExpectationNotMetError, /expected configuration to put .*\s* to .*\s*, but did not/)
+      end
+    end
+
+    context 'when a path is not given' do
+      it "will not raise error when put is in recipe" do
+        fake_recipe.find_and_execute_task('fake:thing')
+        expect do
+          should have_put('fake content')
+        end.to_not raise_error(RSpec::Expectations::ExpectationNotMetError, /expected configuration to put .*\s*, but did not/)
+      end
+
+      it "will raise error when put is not in recipe" do
+        fake_recipe.find_and_execute_task('fake:thing')
+        expect do
+          should have_put('real content')
+        end.to raise_error(RSpec::Expectations::ExpectationNotMetError, /expected configuration to put .*\s*, but did not/)
+      end
+    end
+  end
+
 end

--- a/spec/recipe/fakerecipe.rb
+++ b/spec/recipe/fakerecipe.rb
@@ -14,6 +14,7 @@ require 'capistrano'
               run('do some stuff')
               upload("foo", "/tmp/foo")
               get('/tmp/baz', 'baz')
+              put('fake content', '/tmp/put')
             end
             desc "More fake tasks!"
             task :before_this_execute_thing do


### PR DESCRIPTION
With this matcher you can test if a content (i.e, a string) is
uploaded to the server. You can also test the path.

Example:

``` ruby
it "should have put" do
  @configuration.put 'some: content', '/config.yml'
  @configuration.should have_put('some: content').to('/config.yml')
end
```
