### PR TITLE
Prevent false positives in callback matchers.

### DIFF
--- a/spec/capistrano-spec_spec.rb
+++ b/spec/capistrano-spec_spec.rb
@@ -53,16 +53,55 @@ describe Capistrano::Spec do
   end
 
   describe 'callback' do
+    context 'before callbacks' do
+      ['fake:before_this_execute_thing',
+       'fake:before_this_also_execute_thing',
+       'outside:undefined_task'].each do |task|
+        it "will not raise error when `before` callback has occured for #{task}" do
+          expect do
+            should callback('fake:thing').before(task)
+          end.to_not raise_error(
+            RSpec::Expectations::ExpectationNotMetError,
+            /expected configuration to callback .*\s* before .*\s*, but did not/
+          )
+        end
+      end
 
-    ['fake:before_this_execute_thing', "fake:before_this_also_execute_thing"].each do |task|
-      it "will not raise error when `before` callback has occured for #{task}" do
-        fake_recipe.should callback('fake:thing').before(task)
+      ['undefined_task', 'fake:before_this_dont_execute_thing'].each do |task|
+        it "will raise error when `before` callback hasn't occured for '#{task}'" do
+          expect do
+            should_not callback('fake:thing').before(task)
+          end.to_not raise_error(
+            RSpec::Expectations::ExpectationNotMetError,
+            /expected configuration to not callback .*\s* before .*\s*, but did/
+          )
+        end
       end
     end
 
-    ['fake:after_this_execute_thing', "fake:after_this_also_execute_thing"].each do |task|
-      it "will not raise error when `after` callback has occured for #{task}" do
-        fake_recipe.should callback('fake:thing').after(task)
+    context 'after callbacks' do
+      ['fake:after_this_execute_thing',
+       'fake:after_this_also_execute_thing',
+       'outside:undefined_task'].each do |task|
+        it "will not raise error when `after` callback has occured for #{task}" do
+          expect do
+            should callback('fake:thing').after(task)
+          end.to_not raise_error(
+            RSpec::Expectations::ExpectationNotMetError,
+            /expected configuration to callback .*\s* after .*\s*, but did not/
+          )
+        end
+      end
+
+      ['undefined_task', 'fake:after_this_dont_execute_thing'].each do |task|
+        it "will raise error when `after` callback hasn't occured for '#{task}'" do
+          expect do
+            should_not callback('fake:thing').after(task)
+          end.to_not raise_error(
+            RSpec::Expectations::ExpectationNotMetError,
+            /expected configuration to not callback .*\s* after .*\s*, but did/
+          )
+        end
       end
     end
   end

--- a/spec/capistrano-spec_spec.rb
+++ b/spec/capistrano-spec_spec.rb
@@ -54,54 +54,46 @@ describe Capistrano::Spec do
 
   describe 'callback' do
     context 'before callbacks' do
-      ['fake:before_this_execute_thing',
-       'fake:before_this_also_execute_thing',
-       'outside:undefined_task'].each do |task|
-        it "will not raise error when `before` callback has occured for #{task}" do
-          expect do
-            should callback('fake:thing').before(task)
-          end.to_not raise_error(
-            RSpec::Expectations::ExpectationNotMetError,
-            /expected configuration to callback .*\s* before .*\s*, but did not/
-          )
-        end
+      it_should_behave_like 'correct before callback' do
+        let(:task_name) { 'fake:before_this_execute_thing' }
       end
 
-      ['undefined_task', 'fake:before_this_dont_execute_thing'].each do |task|
-        it "will raise error when `before` callback hasn't occured for '#{task}'" do
-          expect do
-            should_not callback('fake:thing').before(task)
-          end.to_not raise_error(
-            RSpec::Expectations::ExpectationNotMetError,
-            /expected configuration to not callback .*\s* before .*\s*, but did/
-          )
-        end
+      it_should_behave_like 'correct before callback' do
+        let(:task_name) { 'fake:before_this_also_execute_thing' }
+      end
+
+      it_should_behave_like 'correct before callback' do
+        let(:task_name) { 'outside:undefined_task' }
+      end
+
+      it_should_behave_like 'incorrect before callback' do
+        let(:task_name) { 'undefined_task' }
+      end
+
+      it_should_behave_like 'incorrect before callback' do
+        let(:task_name) { 'fake:before_this_dont_execute_thing' }
       end
     end
 
     context 'after callbacks' do
-      ['fake:after_this_execute_thing',
-       'fake:after_this_also_execute_thing',
-       'outside:undefined_task'].each do |task|
-        it "will not raise error when `after` callback has occured for #{task}" do
-          expect do
-            should callback('fake:thing').after(task)
-          end.to_not raise_error(
-            RSpec::Expectations::ExpectationNotMetError,
-            /expected configuration to callback .*\s* after .*\s*, but did not/
-          )
-        end
+      it_should_behave_like 'correct after callback' do
+        let(:task_name) { 'fake:after_this_execute_thing' }
       end
 
-      ['undefined_task', 'fake:after_this_dont_execute_thing'].each do |task|
-        it "will raise error when `after` callback hasn't occured for '#{task}'" do
-          expect do
-            should_not callback('fake:thing').after(task)
-          end.to_not raise_error(
-            RSpec::Expectations::ExpectationNotMetError,
-            /expected configuration to not callback .*\s* after .*\s*, but did/
-          )
-        end
+      it_should_behave_like 'correct after callback' do
+        let(:task_name) { 'fake:after_this_also_execute_thing' }
+      end
+
+      it_should_behave_like 'correct after callback' do
+        let(:task_name) { 'outside:undefined_task' }
+      end
+
+      it_should_behave_like 'incorrect after callback' do
+        let(:task_name) { 'undefined_task' }
+      end
+
+      it_should_behave_like 'incorrect after callback' do
+        let(:task_name) { 'fake:after_this_dont_execute_thing' }
       end
     end
   end
@@ -112,14 +104,20 @@ describe Capistrano::Spec do
         fake_recipe.find_and_execute_task('fake:thing')
         expect do
           should have_put('fake content').to('/tmp/put')
-        end.to_not raise_error(RSpec::Expectations::ExpectationNotMetError, /expected configuration to put .*\s* to .*\s*, but did not/)
+        end.to_not raise_error(
+          RSpec::Expectations::ExpectationNotMetError,
+          /expected configuration to put .*\s* to .*\s*, but did not/
+        )
       end
 
       it "will raise error when put is not in recipe" do
         fake_recipe.find_and_execute_task('fake:thing')
         expect do
           should have_put('real content').to('/tmp/wherever')
-        end.to raise_error(RSpec::Expectations::ExpectationNotMetError, /expected configuration to put .*\s* to .*\s*, but did not/)
+        end.to raise_error(
+          RSpec::Expectations::ExpectationNotMetError,
+          /expected configuration to put .*\s* to .*\s*, but did not/
+        )
       end
     end
 
@@ -128,14 +126,20 @@ describe Capistrano::Spec do
         fake_recipe.find_and_execute_task('fake:thing')
         expect do
           should have_put('fake content')
-        end.to_not raise_error(RSpec::Expectations::ExpectationNotMetError, /expected configuration to put .*\s*, but did not/)
+        end.to_not raise_error(
+          RSpec::Expectations::ExpectationNotMetError,
+          /expected configuration to put .*\s*, but did not/
+        )
       end
 
       it "will raise error when put is not in recipe" do
         fake_recipe.find_and_execute_task('fake:thing')
         expect do
           should have_put('real content')
-        end.to raise_error(RSpec::Expectations::ExpectationNotMetError, /expected configuration to put .*\s*, but did not/)
+        end.to raise_error(
+          RSpec::Expectations::ExpectationNotMetError,
+          /expected configuration to put .*\s*, but did not/
+        )
       end
     end
   end

--- a/spec/recipe/fakerecipe.rb
+++ b/spec/recipe/fakerecipe.rb
@@ -5,8 +5,12 @@ require 'capistrano'
         configuration.load do
           before "fake:before_this_execute_thing", "fake:thing"
           before "fake:before_this_also_execute_thing", "fake:thing"
+          before "outside:undefined_task", "fake:thing"
+
           after "fake:after_this_execute_thing", "fake:thing"
           after "fake:after_this_also_execute_thing", "fake:thing"
+          after "outside:undefined_task", "fake:thing"
+
           namespace :fake do
             desc "thing and run fake manifests"
             task :thing do
@@ -24,10 +28,16 @@ require 'capistrano'
             task :before_this_also_execute_thing do
               #
             end
+            task :before_this_dont_execute_thing do
+              #
+            end
             task :after_this_execute_thing do
               #
             end
             task :after_this_also_execute_thing do
+              #
+            end
+            task :after_this_dont_execute_thing do
               #
             end
           end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -5,7 +5,9 @@ require 'capistrano-spec'
 require 'rspec'
 require 'rspec/autorun'
 
+Dir["./spec/support/**/*.rb"].sort.each { |f| require f }
+
 RSpec.configure do |config|
-	config.include Capistrano::Spec::Matchers
-	config.include Capistrano::Spec::Helpers
+  config.include Capistrano::Spec::Matchers
+  config.include Capistrano::Spec::Helpers
 end

--- a/spec/support/shared/callback_examples.rb
+++ b/spec/support/shared/callback_examples.rb
@@ -1,0 +1,43 @@
+shared_examples 'correct before callback' do
+  it "won't raise error when `before` callback has occured for the given task" do
+    expect do
+      should callback('fake:thing').before(task_name)
+    end.to_not raise_error(
+      RSpec::Expectations::ExpectationNotMetError,
+      /expected configuration to callback .*\s* before .*\s*, but did not/
+    )
+  end
+end
+
+shared_examples 'incorrect before callback' do
+  it "will raise error when `before` callback hasn't occured for the given task" do
+    expect do
+      should_not callback('fake:thing').before(task_name)
+    end.to_not raise_error(
+      RSpec::Expectations::ExpectationNotMetError,
+      /expected configuration to not callback .*\s* before .*\s*, but did/
+    )
+  end
+end
+
+shared_examples 'correct after callback' do
+  it "won't raise error when `after` callback has occured for the given task" do
+    expect do
+      should callback('fake:thing').after(task_name)
+    end.to_not raise_error(
+      RSpec::Expectations::ExpectationNotMetError,
+      /expected configuration to callback .*\s* after .*\s*, but did not/
+    )
+  end
+end
+
+shared_examples 'incorrect after callback' do
+  it "will raise error when `after` callback hasn't occured for the given task" do
+    expect do
+      should_not callback('fake:thing').after(task_name)
+    end.to_not raise_error(
+      RSpec::Expectations::ExpectationNotMetError,
+      /expected configuration to not callback .*\s* after .*\s*, but did/
+    )
+  end
+end


### PR DESCRIPTION
When you call the `#callback` matcher and pass an undefined task to the `#before` or `#after` methods of the matcher, this always returns true, even if the `before` callback is not defined in the recipe.

This happens because the `configuration` object inside the specs may not have defined the task for the callback. Then, when the matcher method tries to find the task, it always find a `nil` object which always returns true in the capistrano method `#applies_to?`.

The `#callback` matcher should check if a capistrano callback has been defined, not if a taks exists, that's why I stub the task if isn't found. That way you can prevent false positives.
