### PR TITLE
Add the license to gemspec.

### DIFF
--- a/capistrano-spec.gemspec
+++ b/capistrano-spec.gemspec
@@ -40,6 +40,7 @@ Gem::Specification.new do |s|
   s.require_paths = ["lib"]
   s.rubygems_version = "1.8.23"
   s.summary = "Test your capistrano recipes"
+  s.license = "MIT"
 
   if s.respond_to? :specification_version then
     s.specification_version = 3


### PR DESCRIPTION
To see why this attribute is important in the gemspec, see the following
links:
- https://github.com/technicalpickles/capistrano-spec/issues/17
- http://www.benjaminfleischer.com/2013/07/12/make-the-world-a-better-place-put-a-license-in-your-gemspec/
